### PR TITLE
Use dicts instead of lists

### DIFF
--- a/overpy/__about__.py
+++ b/overpy/__about__.py
@@ -13,7 +13,7 @@ __title__ = "overpy"
 __summary__ = "Python Wrapper to access the OpenStreepMap Overpass API"
 __uri__ = "https://github.com/DinoTools/python-overpy"
 
-__version__ = "0.2.2"
+__version__ = "0.3.0dev1"
 
 __author__ = "PhiBo (DinoTools)"
 __email__ = ""

--- a/overpy/__about__.py
+++ b/overpy/__about__.py
@@ -13,7 +13,7 @@ __title__ = "overpy"
 __summary__ = "Python Wrapper to access the OpenStreepMap Overpass API"
 __uri__ = "https://github.com/DinoTools/python-overpy"
 
-__version__ = "0.2.0"
+__version__ = "0.2.2"
 
 __author__ = "PhiBo (DinoTools)"
 __email__ = ""

--- a/overpy/__init__.py
+++ b/overpy/__init__.py
@@ -462,7 +462,7 @@ class Node(Element):
         self.lat = lat
         self.lon = lon
         
-    def __str__(self, *args, **kwargs):
+    def __repr__(self):
         return "<overpy.Node id={} lat={} lon={}>".format(self.id, self.lat, self.lon)
 
     @classmethod
@@ -573,7 +573,7 @@ class Way(Element):
         #: List of Ids of the associated nodes
         self._node_ids = node_ids
         
-    def __str__(self, *args, **kwargs):
+    def __repr__(self):
         return "<overpy.Way id={} nodes={}>".format(self.id, self._node_ids)
 
     @property
@@ -744,7 +744,7 @@ class Relation(Element):
         self.id = rel_id
         self.members = members
         
-    def __str__(self, *args, **kwargs):
+    def __repr__(self):
         return "<overpy.Relation id={}>".format(self.id)
 
     @classmethod
@@ -920,7 +920,7 @@ class RelationNode(RelationMember):
     def resolve(self, resolve_missing=False):
         return self._result.get_node(self.ref, resolve_missing=resolve_missing)
     
-    def __str__(self, *args, **kwargs):
+    def __repr__(self):
         return "<overpy.RelationNode ref={} role={}>".format(self.ref, self.role)
 
 
@@ -930,5 +930,5 @@ class RelationWay(RelationMember):
     def resolve(self, resolve_missing=False):
         return self._result.get_way(self.ref, resolve_missing=resolve_missing)
     
-    def __str__(self, *args, **kwargs):
+    def __repr__(self):
         return "<overpy.RelationWay ref={} role={}>".format(self.ref, self.role)

--- a/overpy/__init__.py
+++ b/overpy/__init__.py
@@ -23,6 +23,14 @@ elif PY3:
 
 
 def is_valid_type(element, cls):
+    """
+    Test if an element is of a given type.
+
+    :param Element() element: The element instance to test
+    :param Element cls: The element class to test
+    :return: False or True
+    :rtype: Boolean
+    """
     return isinstance(element, cls) and element.id is not None
 
 

--- a/overpy/__init__.py
+++ b/overpy/__init__.py
@@ -453,6 +453,9 @@ class Node(Element):
         self.id = node_id
         self.lat = lat
         self.lon = lon
+        
+    def __str__(self, *args, **kwargs):
+        return "<overpy.Node id={} lat={} lon={}>".format(self.id, self.lat, self.lon)
 
     @classmethod
     def from_json(cls, data, result=None):
@@ -561,6 +564,9 @@ class Way(Element):
 
         #: List of Ids of the associated nodes
         self._node_ids = node_ids
+        
+    def __str__(self, *args, **kwargs):
+        return "<overpy.Way id={} nodes={}>".format(self.id, self._node_ids)
 
     @property
     def nodes(self):
@@ -729,6 +735,9 @@ class Relation(Element):
         Element.__init__(self, **kwargs)
         self.id = rel_id
         self.members = members
+        
+    def __str__(self, *args, **kwargs):
+        return "<overpy.Relation id={}>".format(self.id)
 
     @classmethod
     def from_json(cls, data, result=None):
@@ -902,6 +911,9 @@ class RelationNode(RelationMember):
 
     def resolve(self, resolve_missing=False):
         return self._result.get_node(self.ref, resolve_missing=resolve_missing)
+    
+    def __str__(self, *args, **kwargs):
+        return "<overpy.RelationNode ref={} role={}>".format(self.ref, self.role)
 
 
 class RelationWay(RelationMember):
@@ -909,3 +921,6 @@ class RelationWay(RelationMember):
 
     def resolve(self, resolve_missing=False):
         return self._result.get_way(self.ref, resolve_missing=resolve_missing)
+    
+    def __str__(self, *args, **kwargs):
+        return "<overpy.RelationWay ref={} role={}>".format(self.ref, self.role)


### PR DESCRIPTION
Using lists for the result nodes is very slow. This change uses dicts to improve access speed. Fixes #9 