### PR TITLE
Add an option for overpass.osm.rambler.ru

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+0.3.2 (2015-08-25)
+~~~~~~~~~~~~~~~~~~
+
+* Add an option to use http://overpass.osm.rambler.ru/cgi/
+  as the base url.
+
+
 0.3.1 (2015-04-30)
 ~~~~~~~~~~~~~~~~~~
 

--- a/overpy/__about__.py
+++ b/overpy/__about__.py
@@ -13,7 +13,7 @@ __title__ = "overpy"
 __summary__ = "Python Wrapper to access the OpenStreepMap Overpass API"
 __uri__ = "https://github.com/DinoTools/python-overpy"
 
-__version__ = "0.3.1"
+__version__ = "0.3.2"
 
 __author__ = "PhiBo (DinoTools)"
 __email__ = ""

--- a/overpy/__init__.py
+++ b/overpy/__init__.py
@@ -45,14 +45,19 @@ class Overpass(object):
     """
     default_read_chunk_size = 4096
 
-    def __init__(self, read_chunk_size=None, xml_parser=XML_PARSER_SAX):
+    def __init__(self, read_chunk_size=None, xml_parser=XML_PARSER_SAX, use_alt_url=False):
         """
         :param read_chunk_size: Max size of each chunk read from the server response
         :type read_chunk_size: Integer
         :param xml_parser: The xml parser to use
         :type xml_parser: Integer
+        :param: use_alt_url: Set to True to use the rambler.ru instance
+        :type use_alt_url: Boolean
         """
+        
         self.url = "http://overpass-api.de/api/interpreter"
+        if use_alt_url:
+            self.url = "http://overpass.osm.rambler.ru/cgi/interpreter"
         self._regex_extract_error_msg = re.compile(b"\<p\>(?P<msg>\<strong\s.*?)\</p\>")
         self._regex_remove_tag = re.compile(b"<[^>]*?>")
         if read_chunk_size is None:


### PR DESCRIPTION
Since the primary overpass instance has been down for some time now, I
made a workaround to use overpass.osm.rambler.ru that still seems to be
online