### PR TITLE
Support parsing of <center> element for ways (XML only)

### DIFF
--- a/overpy/__init__.py
+++ b/overpy/__init__.py
@@ -752,8 +752,8 @@ class Way(Element):
                 ref_id = int(ref_id)
                 node_ids.append(ref_id)
             if sub_child.tag.lower() == "center":
-                center_lat = sub_child.attrib.get("lat")
-                center_lon = sub_child.attrib.get("lon")
+                center_lat = Decimal(sub_child.attrib.get("lat"))
+                center_lon = Decimal(sub_child.attrib.get("lon"))
                 if center_lat is None or center_lon is None:
                     raise ValueError("Unable to get lat/lon of way center.")
 

--- a/overpy/__init__.py
+++ b/overpy/__init__.py
@@ -735,6 +735,8 @@ class Way(Element):
 
         tags = {}
         node_ids = []
+        center_lat = None
+        center_lon = None
 
         for sub_child in child:
             if sub_child.tag.lower() == "tag":

--- a/overpy/__init__.py
+++ b/overpy/__init__.py
@@ -592,7 +592,7 @@ class Way(Element):
 
     _type_value = "way"
 
-    def __init__(self, way_id=None, node_ids=None, **kwargs):
+    def __init__(self, way_id=None, center_lat=None, center_lon=None, node_ids=None, **kwargs):
         """
         :param node_ids: List of node IDs
         :type node_ids: List or Tuple
@@ -608,6 +608,10 @@ class Way(Element):
 
         #: List of Ids of the associated nodes
         self._node_ids = node_ids
+        
+        #: The lat/lon of the center of the way (optional depending on query)
+        self.center_lat = center_lat
+        self.center_lon = center_lon
 
     def __repr__(self):
         return "<overpy.Way id={} nodes={}>".format(self.id, self._node_ids)
@@ -745,6 +749,11 @@ class Way(Element):
                     raise ValueError("Unable to find required ref value.")
                 ref_id = int(ref_id)
                 node_ids.append(ref_id)
+            if sub_child.tag.lower() == "center":
+                center_lat = sub_child.attrib.get("lat")
+                center_lon = sub_child.attrib.get("lon")
+                if center_lat is None or center_lon is None:
+                    raise ValueError("Unable to get lat/lon of way center.")
 
         way_id = child.attrib.get("id")
         if way_id is not None:
@@ -757,7 +766,8 @@ class Way(Element):
                 continue
             attributes[n] = v
 
-        return cls(way_id=way_id, attributes=attributes, node_ids=node_ids, tags=tags, result=result)
+        return cls(way_id=way_id, center_lat=center_lat, center_lon=center_lon,
+                   attributes=attributes, node_ids=node_ids, tags=tags, result=result)
 
 
 class Relation(Element):
@@ -990,7 +1000,7 @@ class OSMSAXHandler(handler.ContentHandler):
     #: Tuple of opening elements to ignore
     ignore_start = ('osm', 'meta', 'note')
     #: Tuple of closing elements to ignore
-    ignore_end = ('osm', 'meta', 'note', 'tag', 'nd', 'member')
+    ignore_end = ('osm', 'meta', 'note', 'center', 'tag', 'nd', 'member')
 
     def __init__(self, result):
         """
@@ -1033,6 +1043,18 @@ class OSMSAXHandler(handler.ContentHandler):
             raise KeyError("Unknown element end '%s'" % name)
         handler()
 
+    def _handle_start_center(self, attrs):
+        """
+        Handle opening center element
+
+        :param attrs: Attributes of the element
+        :type attrs: Dict
+        """
+        if attrs.get('lat', None) is not None:
+            self._curr['center_lat'] = Decimal(attrs['lat'])
+        if attrs.get('lon', None) is not None:
+            self._curr['center_lon'] = Decimal(attrs['lon'])
+    
     def _handle_start_tag(self, attrs):
         """
         Handle opening tag element
@@ -1085,6 +1107,8 @@ class OSMSAXHandler(handler.ContentHandler):
         :type attrs: Dict
         """
         self._curr = {
+            'center_lat': None,
+            'center_lon': None,
             'attributes': dict(attrs),
             'node_ids': [],
             'tags': {},

--- a/overpy/__init__.py
+++ b/overpy/__init__.py
@@ -1030,7 +1030,7 @@ class OSMSAXHandler(handler.ContentHandler):
         try:
             handler = getattr(self, '_handle_end_%s' % name)
         except AttributeError:
-            raise KeyError("Unknown element start '%s'" % name)
+            raise KeyError("Unknown element end '%s'" % name)
         handler()
 
     def _handle_start_tag(self, attrs):

--- a/tests/base_class.py
+++ b/tests/base_class.py
@@ -279,3 +279,59 @@ class BaseTestWay(object):
         for way_ids in (result.way_ids, result.get_way_ids()):
             assert len(way_ids) == 1
             assert way_ids[0] == 317146077
+
+    def _test_way03(self, result):
+        assert len(result.nodes) == 0
+        assert len(result.relations) == 0
+        assert len(result.ways) == 1
+
+        way = result.ways[0]
+
+        assert isinstance(way, overpy.Way)
+        assert isinstance(way.id, int)
+        assert way.id == 317146077
+
+        assert isinstance(way.tags, dict)
+        assert len(way.tags) == 1
+        assert way.tags["building"] == "yes"
+
+        assert isinstance(way.center_lat, Decimal)
+        assert isinstance(way.center_lon, Decimal)
+        assert way.center_lat == Decimal("50.7494852")
+        assert way.center_lon == Decimal("7.1757466")
+
+        # the three assertions following this could break if the live OSM data changes
+        nodes = way.get_nodes(resolve_missing=True)
+
+        assert len(nodes) == 7
+
+        node = nodes[0]
+
+        assert isinstance(node, overpy.Node)
+        assert node.id == 3233854241
+
+        # try to get a single way by id
+        way = result.get_way(317146077)
+        assert way.id == 317146077
+
+        # try to get a single way by id not available in the result
+        with pytest.raises(overpy.exception.DataIncomplete):
+            result.get_way(123456)
+
+        # node_ids is an alias for get_node_ids() and should return the same data
+        for node_ids in (result.node_ids, result.get_node_ids()):
+            assert len(node_ids) == 6
+            assert node_ids[0] == 3233854233
+            assert node_ids[1] == 3233854234
+            assert node_ids[2] == 3233854236
+            assert node_ids[3] == 3233854237
+            assert node_ids[4] == 3233854238
+            assert node_ids[5] == 3233854241
+
+        assert len(result.relation_ids) == 0
+        assert len(result.get_relation_ids()) == 0
+
+        # way_ids is an alias for get_way_ids() and should return the same data
+        for way_ids in (result.way_ids, result.get_way_ids()):
+            assert len(way_ids) == 1
+            assert way_ids[0] == 317146077

--- a/tests/base_class.py
+++ b/tests/base_class.py
@@ -281,7 +281,7 @@ class BaseTestWay(object):
             assert way_ids[0] == 317146077
 
     def _test_way03(self, result):
-        assert len(result.nodes) == 0
+        assert len(result.nodes) == 6
         assert len(result.relations) == 0
         assert len(result.ways) == 1
 
@@ -300,8 +300,7 @@ class BaseTestWay(object):
         assert way.center_lat == Decimal("50.7494852")
         assert way.center_lon == Decimal("7.1757466")
 
-        # the three assertions following this could break if the live OSM data changes
-        nodes = way.get_nodes(resolve_missing=True)
+        nodes = way.nodes
 
         assert len(nodes) == 7
 

--- a/tests/test_xml.py
+++ b/tests/test_xml.py
@@ -56,6 +56,15 @@ class TestWay(BaseTestWay):
         result = api.parse_xml(read_file("xml/way-02.xml"), parser=overpy.XML_PARSER_SAX)
         self._test_way02(result)
 
+    def test_way03(self):
+        api = overpy.Overpass()
+        # DOM
+        result = api.parse_xml(read_file("xml/way-03.xml"), parser=overpy.XML_PARSER_DOM)
+        self._test_way03(result)
+        # SAX
+        result = api.parse_xml(read_file("xml/way-03.xml"), parser=overpy.XML_PARSER_SAX)
+        self._test_way03(result)
+
 
 class TestDataError(object):
     def _get_element_wrong_type(self):

--- a/tests/xml/way-03.xml
+++ b/tests/xml/way-03.xml
@@ -1,8 +1,14 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <osm version="0.6" generator="Overpass API">
 <note>The data included in this document is from www.openstreetmap.org. The data is made available under ODbL.</note>
-<meta osm_base="2016-04-13T16:48:02Z"/>
+<meta osm_base="2016-04-13T17:17:02Z"/>
 
+  <node id="3233854233" lat="50.7494187" lon="7.1758731"/>
+  <node id="3233854234" lat="50.7494236" lon="7.1757664"/>
+  <node id="3233854236" lat="50.7494909" lon="7.1757741"/>
+  <node id="3233854237" lat="50.7494985" lon="7.1756064"/>
+  <node id="3233854238" lat="50.7495391" lon="7.1758868"/>
+  <node id="3233854241" lat="50.7495516" lon="7.1756125"/>
   <way id="317146077">
     <center lat="50.7494852" lon="7.1757466"/>
     <nd ref="3233854241"/>

--- a/tests/xml/way-03.xml
+++ b/tests/xml/way-03.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<osm version="0.6" generator="Overpass API">
+<note>The data included in this document is from www.openstreetmap.org. The data is made available under ODbL.</note>
+<meta osm_base="2016-04-13T16:48:02Z"/>
+
+  <way id="317146077">
+    <center lat="50.7494852" lon="7.1757466"/>
+    <nd ref="3233854241"/>
+    <nd ref="3233854238"/>
+    <nd ref="3233854233"/>
+    <nd ref="3233854234"/>
+    <nd ref="3233854236"/>
+    <nd ref="3233854237"/>
+    <nd ref="3233854241"/>
+    <tag k="building" v="yes"/>
+  </way>
+
+</osm>


### PR DESCRIPTION
The 'out center' Overpass QL option provides a centroid for each way in a <center> element. I've added support for parsing the <center> element, but N.B. only for ways (not relations) and only for XML (not JSON).

I've also corrected a mistake in the 'Unknown element end' KeyError message.
