### PR TITLE
Include attributes into RelationMembers.

### DIFF
--- a/overpy/__init__.py
+++ b/overpy/__init__.py
@@ -892,7 +892,7 @@ class RelationMember(object):
     Base class to represent a member of a relation.
     """
 
-    def __init__(self, ref=None, role=None, result=None):
+    def __init__(self, attributes=None, ref=None, role=None, result=None):
         """
         :param ref: Reference Id
         :type ref: Integer
@@ -903,6 +903,7 @@ class RelationMember(object):
         self.ref = ref
         self._result = result
         self.role = role
+        self.attributes = attributes
 
     @classmethod
     def from_json(cls, data, result=None):
@@ -925,7 +926,15 @@ class RelationMember(object):
 
         ref = data.get("ref")
         role = data.get("role")
-        return cls(ref=ref, role=role, result=result)
+
+        attributes = {}
+        ignore = ["type", "ref", "role"]
+        for n, v in data.items():
+            if n in ignore:
+                continue
+            attributes[n] = v
+
+        return cls(attributes=None, ref=ref, role=role, result=result)
 
     @classmethod
     def from_xml(cls, child, result=None):
@@ -950,7 +959,15 @@ class RelationMember(object):
         if ref is not None:
             ref = int(ref)
         role = child.attrib.get("role")
-        return cls(ref=ref, role=role, result=result)
+
+        attributes = {}
+        ignore = ["ref", "role"]
+        for n, v in child.attrib.items():
+            if n in ignore:
+                continue
+            attributes[n] = v
+
+        return cls(attributes=attributes, ref=ref, role=role, result=result)
 
 
 class RelationNode(RelationMember):

--- a/overpy/__init__.py
+++ b/overpy/__init__.py
@@ -934,7 +934,7 @@ class RelationMember(object):
                 continue
             attributes[n] = v
 
-        return cls(attributes=None, ref=ref, role=role, result=result)
+        return cls(attributes=attributes, ref=ref, role=role, result=result)
 
     @classmethod
     def from_xml(cls, child, result=None):


### PR DESCRIPTION
When making queries that return relations and geometries (**out geom;**) the member's attributes were not present in the RelationMember object, making it impossible to retrieve the geometries of these members. This could not be fixed by using _resolve()_ because it's Overpass QL clause (**out body;**). Besides, the data (geometries in this case) is already on the response, so new resolve queries for each member would cause unnecessary overhead.

This change allows the following snippet to work (it creates a WKT representation of the relation):

```
relation_geometry = 'MULTIPOLYGON('
for i, member in enumerate(relation.members):
    coords = '(('
    for j, point in enumerate(member.attributes['geometry']):
        coords += str(point['lon']) + " " + str(point['lat'])
        if j < len(member.attributes['geometry'])-1:
            coords += ','

    coords += '))'
    if i < len(relation.members)-1:
        coords += ','

    relation_geometry += coords

relation_geometry += ')'
```
