### PR TITLE
Fixed unicode to byte array conversion in Python 2.*

### DIFF
--- a/overpy/__init__.py
+++ b/overpy/__init__.py
@@ -69,7 +69,7 @@ class Overpass(object):
         :rtype: overpy.Result
         """
         if not isinstance(query, bytes):
-            query = bytes(query, "utf-8")
+            query = query.encode("utf-8")
 
         try:
             f = urlopen(self.url, query)


### PR DESCRIPTION
The `bytes` function in Python 2 is an alias of `str()` which takes only one argument. Changed the way unicode query strings are converted to utf-8 byte arrays.