### PR TITLE
add 'tests' to the excluded packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
     ],
     keywords="OverPy Overpass OSM OpenStreetMap",
     install_requires=[],
-    packages=find_packages(exclude=["*.tests", "*.tests.*"]),
+    packages=find_packages(exclude=["*.tests", "*.tests.*", "tests"]),
     include_package_data=True,
     package_data={
         #"": ["README"],


### PR DESCRIPTION
##### Issue type
 - Bugfix

##### Summary

Add 'tests' to the exclude patterns for packages so that the included tests don't get installed on user's systems and potentially conflict with other packages that include "tests".

<!---
If you are fixing an existing issue, please include also "Fixes #nnn" in your commit message.
Please respect the preferred format of the commit message.
-->
