### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,11 +5,11 @@ A Python Wrapper to access the Overpass API.
 
 Have a look at the `documentation`_ to find additional information.
 
-.. image:: https://pypip.in/version/overpy/badge.svg
+.. image:: https://img.shields.io/pypi/v/overpy.svg
     :target: https://pypi.python.org/pypi/overpy/
     :alt: Latest Version
 
-.. image:: https://pypip.in/license/overpy/badge.svg
+.. image:: https://img.shields.io/pypi/l/overpy.svg
     :target: https://pypi.python.org/pypi/overpy/
     :alt: License
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20overpy))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `overpy`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.