### PR TITLE
Remove Python 2 support

### DIFF
--- a/docs/source/introduction.rst
+++ b/docs/source/introduction.rst
@@ -6,9 +6,8 @@ Requirements
 
 Supported Python versions:
 
-* Python 2.7
-* Python > 3.2
-* PyPy
+* Python 3.6+
+* PyPy3
 
 Installation
 ------------

--- a/examples/get_areas.py
+++ b/examples/get_areas.py
@@ -18,4 +18,4 @@ for area in result.areas:
         )
     )
     for n, v in area.tags.items():
-        print("  Tag: %s = %s" % (n, v))
+        print(f"  Tag: {n} = {v}")

--- a/examples/get_nodes.py
+++ b/examples/get_nodes.py
@@ -5,7 +5,7 @@ api = overpy.Overpass()
 
 # We can also see a node's metadata:
 jet_deau = 60018172
-result = api.query("node({}); out meta;".format(jet_deau))
+result = api.query(f"node({jet_deau}); out meta;")
 node = result.get_node(jet_deau)
 
 print(

--- a/examples/get_ways.py
+++ b/examples/get_ways.py
@@ -15,4 +15,4 @@ for way in result.ways:
     print("  Highway: %s" % way.tags.get("highway", "n/a"))
     print("  Nodes:")
     for node in way.nodes:
-        print("    Lat: %f, Lon: %f" % (node.lat, node.lon))
+        print(f"    Lat: {node.lat:f}, Lon: {node.lon:f}")

--- a/overpy/__init__.py
+++ b/overpy/__init__.py
@@ -4,7 +4,6 @@ from decimal import Decimal
 from xml.sax import handler, make_parser
 import json
 import re
-import sys
 import time
 
 from overpy import exception
@@ -12,9 +11,6 @@ from overpy.__about__ import (
     __author__, __copyright__, __email__, __license__, __summary__, __title__,
     __uri__, __version__
 )
-
-PY2 = sys.version_info[0] == 2
-PY3 = sys.version_info[0] == 3
 
 XML_PARSER_DOM = 1
 XML_PARSER_SAX = 2
@@ -29,12 +25,8 @@ GLOBAL_ATTRIBUTE_MODIFIERS = {
     "visible": lambda v: v.lower() == "true"
 }
 
-if PY2:
-    from urllib2 import urlopen
-    from urllib2 import HTTPError
-elif PY3:
-    from urllib.request import urlopen
-    from urllib.error import HTTPError
+from urllib.request import urlopen
+from urllib.error import HTTPError
 
 
 def is_valid_type(element, cls):
@@ -142,11 +134,7 @@ class Overpass:
             f.close()
 
             if f.code == 200:
-                if PY2:
-                    http_info = f.info()
-                    content_type = http_info.getheader("content-type")
-                else:
-                    content_type = f.getheader("Content-Type")
+                content_type = f.getheader("Content-Type")
 
                 if content_type == "application/json":
                     return self.parse_json(response)
@@ -234,9 +222,6 @@ class Overpass:
 
         if isinstance(data, bytes):
             data = data.decode(encoding)
-        if PY2 and not isinstance(data, str):
-            # Python 2.x: Convert unicode strings
-            data = data.encode(encoding)
 
         m = re.compile("<remark>(?P<msg>[^<>]*)</remark>").search(data)
         if m:
@@ -399,10 +384,7 @@ class Result:
                         result.append(elem_cls.from_xml(child, result=result))
 
         elif parser == XML_PARSER_SAX:
-            if PY2:
-                from StringIO import StringIO
-            else:
-                from io import StringIO
+            from io import StringIO
             source = StringIO(data)
             sax_handler = OSMSAXHandler(result)
             parser = make_parser()

--- a/overpy/__init__.py
+++ b/overpy/__init__.py
@@ -49,7 +49,7 @@ def is_valid_type(element, cls):
     return isinstance(element, cls) and element.id is not None
 
 
-class Overpass(object):
+class Overpass:
     """
     Class to access the Overpass API
 
@@ -78,7 +78,7 @@ class Overpass(object):
         if url is not None:
             self.url = url
 
-        self._regex_extract_error_msg = re.compile(b"\<p\>(?P<msg>\<strong\s.*?)\</p\>")
+        self._regex_extract_error_msg = re.compile(br"\<p\>(?P<msg>\<strong\s.*?)\</p\>")
         self._regex_remove_tag = re.compile(b"<[^>]*?>")
         if read_chunk_size is None:
             read_chunk_size = self.default_read_chunk_size
@@ -245,7 +245,7 @@ class Overpass(object):
         return Result.from_xml(data, api=self, parser=parser)
 
 
-class Result(object):
+class Result:
     """
     Class to handle the result.
     """
@@ -603,7 +603,7 @@ class Result(object):
     ways = property(get_ways)
 
 
-class Element(object):
+class Element:
     """
     Base element
     """
@@ -679,7 +679,7 @@ class Area(Element):
         self.id = area_id
 
     def __repr__(self):
-        return "<overpy.Area id={}>".format(self.id)
+        return f"<overpy.Area id={self.id}>"
 
     @classmethod
     def from_json(cls, data, result=None):
@@ -782,7 +782,7 @@ class Node(Element):
         self.lon = lon
 
     def __repr__(self):
-        return "<overpy.Node id={} lat={} lon={}>".format(self.id, self.lat, self.lon)
+        return f"<overpy.Node id={self.id} lat={self.lat} lon={self.lon}>"
 
     @classmethod
     def from_json(cls, data, result=None):
@@ -897,7 +897,7 @@ class Way(Element):
         self.center_lon = center_lon
 
     def __repr__(self):
-        return "<overpy.Way id={} nodes={}>".format(self.id, self._node_ids)
+        return f"<overpy.Way id={self.id} nodes={self._node_ids}>"
 
     @property
     def nodes(self):
@@ -1086,7 +1086,7 @@ class Relation(Element):
         self.center_lon = center_lon
 
     def __repr__(self):
-        return "<overpy.Relation id={}>".format(self.id)
+        return f"<overpy.Relation id={self.id}>"
 
     @classmethod
     def from_json(cls, data, result=None):
@@ -1211,7 +1211,7 @@ class Relation(Element):
         )
 
 
-class RelationMember(object):
+class RelationMember:
     """
     Base class to represent a member of a relation.
     """
@@ -1340,7 +1340,7 @@ class RelationNode(RelationMember):
         return self._result.get_node(self.ref, resolve_missing=resolve_missing)
 
     def __repr__(self):
-        return "<overpy.RelationNode ref={} role={}>".format(self.ref, self.role)
+        return f"<overpy.RelationNode ref={self.ref} role={self.role}>"
 
 
 class RelationWay(RelationMember):
@@ -1350,16 +1350,16 @@ class RelationWay(RelationMember):
         return self._result.get_way(self.ref, resolve_missing=resolve_missing)
 
     def __repr__(self):
-        return "<overpy.RelationWay ref={} role={}>".format(self.ref, self.role)
+        return f"<overpy.RelationWay ref={self.ref} role={self.role}>"
 
 
-class RelationWayGeometryValue(object):
+class RelationWayGeometryValue:
     def __init__(self, lat, lon):
         self.lat = lat
         self.lon = lon
 
     def __repr__(self):
-        return "<overpy.RelationWayGeometryValue lat={} lon={}>".format(self.lat, self.lon)
+        return f"<overpy.RelationWayGeometryValue lat={self.lat} lon={self.lon}>"
 
 
 class RelationRelation(RelationMember):
@@ -1369,7 +1369,7 @@ class RelationRelation(RelationMember):
         return self._result.get_relation(self.ref, resolve_missing=resolve_missing)
 
     def __repr__(self):
-        return "<overpy.RelationRelation ref={} role={}>".format(self.ref, self.role)
+        return f"<overpy.RelationRelation ref={self.ref} role={self.role}>"
 
 
 class RelationArea(RelationMember):
@@ -1379,7 +1379,7 @@ class RelationArea(RelationMember):
         return self._result.get_area(self.ref, resolve_missing=resolve_missing)
 
     def __repr__(self):
-        return "<overpy.RelationArea ref={} role={}>".format(self.ref, self.role)
+        return f"<overpy.RelationArea ref={self.ref} role={self.role}>"
 
 
 class OSMSAXHandler(handler.ContentHandler):

--- a/overpy/exception.py
+++ b/overpy/exception.py
@@ -31,7 +31,7 @@ class ElementDataWrongType(OverPyException):
         self.type_provided = type_provided
 
     def __str__(self):
-        return "Type expected '%s' but '%s' provided" % (
+        return "Type expected '{}' but '{}' provided".format(
             self.type_expected,
             str(self.type_provided)
         )

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ with open(os.path.join(base_dir, "overpy", "__about__.py")) as f:
 filename_readme = os.path.join(base_dir, "README.rst")
 if sys.version_info[0] == 2:
     import io
-    fp = io.open(filename_readme, encoding="utf-8")
+    fp = open(filename_readme, encoding="utf-8")
 else:
     fp = open(filename_readme, encoding="utf-8")
 long_description = fp.read()

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -3,13 +3,8 @@ import sys
 import threading
 from threading import Lock
 
-PY2 = sys.version_info[0] == 2
-if PY2:
-    from SocketServer import BaseRequestHandler, TCPServer, ThreadingMixIn
-    from BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer
-else:
-    from socketserver import BaseRequestHandler, TCPServer, ThreadingMixIn
-    from http.server import BaseHTTPRequestHandler, HTTPServer
+from socketserver import BaseRequestHandler, TCPServer, ThreadingMixIn
+from http.server import BaseHTTPRequestHandler, HTTPServer
 
 TCPServer.allow_reuse_address = True
 

--- a/tests/base_class.py
+++ b/tests/base_class.py
@@ -9,7 +9,7 @@ import overpy
 from tests import read_file
 
 
-class BaseTestAreas(object):
+class BaseTestAreas:
     def _test_area01(self, result):
         assert len(result.areas) == 4
         assert len(result.nodes) == 0
@@ -76,7 +76,7 @@ class BaseTestAreas(object):
         assert len(result.get_way_ids()) == 0
 
 
-class BaseTestNodes(object):
+class BaseTestNodes:
     def _test_node01(self, result):
         assert len(result.nodes) == 3
         assert len(result.relations) == 0
@@ -150,7 +150,7 @@ class BaseTestNodes(object):
         assert len(result.get_way_ids()) == 0
 
 
-class BaseTestRelation(object):
+class BaseTestRelation:
     def _test_relation01(self, result):
         assert len(result.nodes) == 0
         assert len(result.relations) == 1
@@ -288,7 +288,7 @@ class BaseTestRelation(object):
         assert way.geometry[0].lon == Decimal("6.9813352")
 
 
-class BaseTestWay(object):
+class BaseTestWay:
     def _test_way01(self, result):
         assert len(result.nodes) == 0
         assert len(result.relations) == 0

--- a/tests/test_exception.py
+++ b/tests/test_exception.py
@@ -1,7 +1,7 @@
 import overpy
 
 
-class TestExceptions(object):
+class TestExceptions:
     def test_element_data_wrong_type(self):
         e = overpy.exception.ElementDataWrongType("from1")
         assert e.type_expected == "from1"

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -64,7 +64,7 @@ class TestWay(BaseTestWay):
             api.parse_json(read_file("json/way-04.json"))
 
 
-class TestDataError(object):
+class TestDataError:
     def test_element_wrong_type(self):
         with pytest.raises(overpy.exception.ElementDataWrongType):
             overpy.Node.from_json(
@@ -101,7 +101,7 @@ class TestDataError(object):
             )
 
 
-class TestRemark(object):
+class TestRemark:
     def test_remark_runtime_error(self):
         api = overpy.Overpass()
         with pytest.raises(overpy.exception.OverpassRuntimeError):

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -126,7 +126,7 @@ class HandleRetry(BaseHTTPRequestHandler):
         f(self)
 
 
-class TestQuery(object):
+class TestQuery:
     def test_chunk_size(self):
         url, server = new_server_thread(HandleResponseJSON)
 
@@ -143,10 +143,10 @@ class TestQuery(object):
         api.url = url
         with pytest.raises(overpy.exception.OverpassBadRequest):
             # Missing ; after way(1)
-            api.query((
+            api.query(
                 "way(1)"
                 "out body;"
-            ))
+            )
         stop_server_thread(server)
 
     def test_overpass_syntax_error_encoding_error(self):
@@ -161,10 +161,10 @@ class TestQuery(object):
         api.url = url
         with pytest.raises(overpy.exception.OverpassBadRequest):
             # Missing ; after way(1)
-            api.query((
+            api.query(
                 "way(1)"
                 "out body;"
-            ))
+            )
         stop_server_thread(server)
 
     def test_overpass_too_many_requests(self):
@@ -173,10 +173,10 @@ class TestQuery(object):
         api = overpy.Overpass()
         api.url = url
         with pytest.raises(overpy.exception.OverpassTooManyRequests):
-            api.query((
+            api.query(
                 "way(1);"
                 "out body;"
-            ))
+            )
         stop_server_thread(server)
 
     def test_overpass_gateway_timeout(self):
@@ -185,10 +185,10 @@ class TestQuery(object):
         api = overpy.Overpass()
         api.url = url
         with pytest.raises(overpy.exception.OverpassGatewayTimeout):
-            api.query((
+            api.query(
                 "way(1);"
                 "out body;"
-            ))
+            )
         stop_server_thread(server)
 
     def test_overpass_unknown_status_code(self):
@@ -197,10 +197,10 @@ class TestQuery(object):
         api = overpy.Overpass()
         api.url = url
         with pytest.raises(overpy.exception.OverpassUnknownHTTPStatusCode):
-            api.query((
+            api.query(
                 "way(1);"
                 "out body;"
-            ))
+            )
         stop_server_thread(server)
 
     def test_response_json(self):
@@ -238,8 +238,8 @@ class TestQuery(object):
         api.max_retry_count = len(HandleRetry.default_handler_func) - 1
         api.url = url
         with pytest.raises(overpy.exception.MaxRetriesReached):
-            api.query((
+            api.query(
                 "way(1);"
                 "out body;"
-            ))
+            )
         stop_server_thread(server)

--- a/tests/test_result.py
+++ b/tests/test_result.py
@@ -16,7 +16,7 @@ class HandleResponseJSON02(BaseHTTPRequestHandler):
         self.wfile.write(read_file("json/result-expand-02.json", "rb"))
 
 
-class TestResult(object):
+class TestResult:
     def test_expand_error(self):
         api = overpy.Overpass()
         result = api.parse_json(read_file("json/result-expand-01.json"))
@@ -46,7 +46,7 @@ class TestResult(object):
         assert len(result1.ways) == 2
 
 
-class TestArea(object):
+class TestArea:
     def test_missing_unresolvable(self):
         url, server = new_server_thread(HandleResponseJSON02)
 
@@ -78,7 +78,7 @@ class TestArea(object):
         stop_server_thread(server)
 
 
-class TestNode(object):
+class TestNode:
     def test_missing_unresolvable(self):
         url, server = new_server_thread(HandleResponseJSON02)
 
@@ -127,7 +127,7 @@ class TestPickle(BaseTestWay):
         self._test_way02(new_result)
 
 
-class TestRelation(object):
+class TestRelation:
     def test_missing_unresolvable(self):
         url, server = new_server_thread(HandleResponseJSON02)
 
@@ -159,7 +159,7 @@ class TestRelation(object):
         stop_server_thread(server)
 
 
-class TestWay(object):
+class TestWay:
     def test_missing_unresolvable(self):
         url, server = new_server_thread(HandleResponseJSON02)
 

--- a/tests/test_result_way.py
+++ b/tests/test_result_way.py
@@ -36,7 +36,7 @@ class HandleResponseJSON03(BaseHTTPRequestHandler):
         self.wfile.write(read_file("json/result-way-03.json", "rb"))
 
 
-class TestNodes(object):
+class TestNodes:
     def test_missing_unresolvable(self):
         url, server = new_server_thread(HandleResponseJSON01)
 

--- a/tests/test_xml.py
+++ b/tests/test_xml.py
@@ -105,7 +105,7 @@ class TestWay(BaseTestWay):
             api.parse_xml(read_file("xml/way-04.xml"), parser=overpy.XML_PARSER_SAX)
 
 
-class TestDataError(object):
+class TestDataError:
     def _get_element_wrong_type(self):
         data = "<foo></foo>"
         import xml.etree.ElementTree as ET
@@ -193,7 +193,7 @@ class TestParser(BaseTestNodes):
         self._test_node01(result)
 
 
-class TestRemark(object):
+class TestRemark:
     def test_remark_runtime_error(self):
         api = overpy.Overpass()
         with pytest.raises(overpy.exception.OverpassRuntimeError):


### PR DESCRIPTION
##### Issue type
<!--- Pick one below and delete the rest: -->
 - Feature

##### Summary
<!--- Describe your change. -->

Remove support for Python 2. Python 3.6+ is required now.

<!---
If you are fixing an existing issue, please include also "Fixes #nnn" in your commit message.
Please respect the preferred format of the commit message.
-->
