### PR TITLE
simplify urlopen reading code. make the runtime linear rather than quadratic

### DIFF
--- a/overpy/__init__.py
+++ b/overpy/__init__.py
@@ -133,12 +133,7 @@ class Overpass:
             except HTTPError as e:
                 f = e
 
-            response = f.read(self.read_chunk_size)
-            while True:
-                data = f.read(self.read_chunk_size)
-                if len(data) == 0:
-                    break
-                response = response + data
+            response = f.read()
             f.close()
 
             current_exception: exception.OverPyException


### PR DESCRIPTION
##### Issue type
 - Bugfix

The code hangs when accessing a large query (e.g., all parks in California). This is because the code as written repeatedly adds to a string in a loop. This is (1) not necessary, since you can just run f.read() and (2) unnecessarily slow, as it requires reallocation and copying of the entire string. See, e.g., [this amazon style guide](https://docs.aws.amazon.com/codeguru/detector-library/python/string-concatenation/) for more details.

##### Summary

I replaced a block of code

```
            response = f.read(self.read_chunk_size)
            while True:
                data = f.read(self.read_chunk_size)
                if len(data) == 0:
                    break
                response = response + data
```

with the line

```
response = f.read()
```

This is equivalent