### PR TITLE
Added options to return or include raw data from query

### DIFF
--- a/overpy/__init__.py
+++ b/overpy/__init__.py
@@ -111,11 +111,17 @@ class Overpass:
             raise exception.OverpassRuntimeRemark(msg=msg)
         raise exception.OverpassUnknownError(msg=msg)
 
-    def query(self, query: Union[bytes, str], include_raw: bool = False) -> "Result":
+    def query(
+            self,
+            query: Union[bytes, str],
+            *,
+            raw: bool = False,
+            include_raw: bool = False) -> Union["Result", bytes, str]:
         """
         Query the Overpass API
 
         :param query: The query string in Overpass QL
+        :param raw: True to return the raw response without parsing
         :param include_raw: True to store the raw data along with the parsed result
         :return: The parsed result
         """
@@ -144,6 +150,9 @@ class Overpass:
 
             current_exception: exception.OverPyException
             if f.code == 200:
+                if raw:
+                    return response
+                
                 content_type = f.getheader("Content-Type")
 
                 if content_type == "application/json":

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -116,3 +116,17 @@ class TestRemark:
         api = overpy.Overpass()
         with pytest.raises(overpy.exception.OverpassUnknownError):
             api.parse_json(read_file("json/remark-unknown-01.json"))
+
+
+class TestIncludeRawJSON:
+    def test_include_raw_json(self):
+        api = overpy.Overpass()
+        data = read_file("json/area-01.json")
+        result = api.parse_json(data, include_raw=True)
+        assert result.raw == data
+    
+    def test_not_include_raw(self):
+        api = overpy.Overpass()
+        data = read_file("json/area-01.json")
+        result = api.parse_json(data, include_raw=False)
+        assert result.raw is None

--- a/tests/test_xml.py
+++ b/tests/test_xml.py
@@ -209,3 +209,17 @@ class TestRemark:
         api = overpy.Overpass()
         with pytest.raises(overpy.exception.OverpassUnknownError):
             api.parse_xml(read_file("xml/remark-unknown-01.xml"))
+
+
+class TestIncludeRawXML:
+    def test_include_raw_xml(self):
+        api = overpy.Overpass()
+        data = read_file("xml/area-01.xml")
+        result = api.parse_xml(data, include_raw=True)
+        assert result.raw == data
+    
+    def test_not_include_raw(self):
+        api = overpy.Overpass()
+        data = read_file("xml/area-01.xml")
+        result = api.parse_xml(data, include_raw=False)
+        assert result.raw is None


### PR DESCRIPTION
##### Issue type
 - Feature

##### Summary
Added options to keep the raw XML or JSON response along with the parsed result, or to only return the raw data.
The latter fixes #79.

Example:

```python
api = overpy.Overpass()
result = api.query("[out:json];node[\"ISO3166-1\"=\"France\"];out;", include_raw=True)
print(result.raw)
```

```python
api = overpy.Overpass()
data= api.query("[out:json];node[\"ISO3166-1\"=\"France\"];out;", raw=True)
print(data)
```
